### PR TITLE
Add custom script to build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ OPTIONS:
           Image Format
               --folder   -f   build development sandbox (folder)
               --option   -o   add a custom option to build (-o --fakeroot or -option 'section post' )
-              --writable -w   non-production writable image (ext3)         
+              --writable -w   non-production writable image (ext3)
                               Default is squashfs (recommended) (deprecated)
               --name     -n   provide basename for the container (default based on URI)
               --mount    -m   provide list of custom mount points (in quotes!)
+              --custom   -c   set custom script path for step 9 (default /custom/tosingularity)
               --help     -h   show this help and exit
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ that each option that you specify is captured as a single string. E.g.,:
 
 The last argument (without a letter) is the name of the docker image, as you would specify to run with Docker (e.g., `docker run ubuntu:latest`)
 
+**Custom Install Script**
+
+You can add your own custom step 9 to customize the final image by mounting a bash script to `/custom/tosingularity`. The script will be sourced, so you'll have access to all the `docker2singularity.sh` script variables.
 
 ## Legacy
 
@@ -239,6 +242,27 @@ You can also use `--writable` and convert an ext3 image into a production image:
 
 ```bash
 sudo singularity build ext3.img production.simg
+```
+
+### Custom Script
+
+Here is an example of a custom script, where the `runscript` is copied to `startscript` to support `singularity instance start`:
+
+
+```bash
+# /home/me/custom_script.sh
+
+# Copy the run script to the start script, so that instance starts
+cp "${build_sandbox}/.singularity.d/runscript" "${build_sandbox}/.singularity.d/startscript"
+```
+
+```bash
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+           -v /tmp/test:/output \
+           -v /home/me/custom_script.sh:/custom/tosingularity \
+           --privileged -t --rm \
+           quay.io/singularity/docker2singularity \
+           ubuntu:14.04
 ```
 
 ### Contributed Examples

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The last argument (without a letter) is the name of the docker image, as you wou
 
 **Custom Install Script**
 
-You can add your own custom step 9 to customize the final image by mounting a bash script to `/custom/tosingularity`. The script will be sourced, so you'll have access to all the `docker2singularity.sh` script variables.
+You can add your own custom step 9 to customize the final image by mounting a bash script to `/custom/tosingularity` (or a path specified with `-c`/`--custom`). The docker image will be searched for the same path and used if found there. The script will be sourced, so you'll have access to all the `docker2singularity.sh` script variables.
 
 ## Legacy
 

--- a/docker2singularity.sh
+++ b/docker2singularity.sh
@@ -325,6 +325,9 @@ echo "(9/11) Custom script..."
 if [ -r "${custom_script}" ]; then
   source "${custom_script}"
 fi
+if [ -r "${build_sandbox}/${custom_script}" ]; then
+  source "${build_sandbox}/${custom_script}"
+fi
 
 # Build a final image from the sandbox
 echo "(10/11) Building ${image_format} container..."

--- a/docker2singularity.sh
+++ b/docker2singularity.sh
@@ -49,6 +49,7 @@ function usage() {
                               Default is squashfs (recommended) (deprecated)
               --name     -n   provide basename for the container (default based on URI)
               --mount    -m   provide list of custom mount points (in quotes!)
+              --custom   -c   set custom script path for step 9 (default /custom/tosingularity)
               --help     -h   show this help and exit
               "
 }
@@ -62,6 +63,7 @@ fi
 mount_points="/oasis /projects /scratch /local-scratch /work /home1 /corral-repl /corral-tacc /beegfs /share/PI /extra /data /oak"
 image_format="squashfs"
 new_container_name=""
+custom_script=/custom/tosingularity
 options=""
 
 while true; do
@@ -93,6 +95,10 @@ while true; do
             shift
             image_format="writable"
         ;;
+        -c|--custom)
+            shift
+            custom_script="${1:-}"
+            shift
         :) printf "missing argument for -%s\n" "$option" >&2
            usage
            exit 1
@@ -316,8 +322,8 @@ docker stop $container_id >> /dev/null
 docker rm $container_id >> /dev/null
 
 echo "(9/11) Custom script..."
-if [ -r /custom/tosingularity ]; then
-  source /custom/tosingularity
+if [ -r "${custom_script}" ]; then
+  source "${custom_script}"
 fi
 
 # Build a final image from the sandbox


### PR DESCRIPTION
Add the option to mount in a script at `/custom/tosingularity` that will be sourced as the new step 9.

I think this feature will greatly increase the number of custom scenarios that can be covered without having to add code for every little feature that not everyone would want:

For example:
- I want to auto remove `tini` from my entrypoint, but that's specific to my use case, and shouldn't be a feature of this repo, but is fairly useful in my auto docker->singularity conversions.
- I want to copy the `runscript` to `startscript` so I can `instance start` a container and get the desired result (entrypoint + cmd). This is probably also a very specific use case.
- Etc...

A second way to use this feature is to add the custom script to the docker image at `/custom/tosingularity`, then run it via `${build_sandbox}/custom/tosingularity`. But I thought making that the main way to use this was a little sillier in the end.